### PR TITLE
My fixes for the Magritte booklet

### DIFF
--- a/Chapters/Magritte/Magritte.pillar
+++ b/Chapters/Magritte/Magritte.pillar
@@ -279,7 +279,7 @@ As a result we get a complete address editor, as seen in Figure *@addressSaveCan
 
 !!! Conclusion
 
-In summary Magritte is  easy to use with Seaside. You put your descriptions according to a naming-convention. You can then ask your model objects for their descriptions by sending the message ==description== or alternatively you directly ask Magritte to build a Seaside editor for you by sending the message ==asComponent==.
+In summary Magritte is  easy to use with Seaside. You put your descriptions according to a naming-convention. You can then ask your model objects for their descriptions by sending the message ==magritteDescription== or alternatively you directly ask Magritte to build a Seaside editor for you by sending the message ==asComponent==.
 
 
 

--- a/Chapters/Magritte/MagritteTutorial.pillar
+++ b/Chapters/Magritte/MagritteTutorial.pillar
@@ -2,11 +2,11 @@
 
 This chapter presents some exercises about Magritte. They are based on the Magritte Tutorial written by Lukas Renggli. We thank him for Magritte and this set of exercises. The exercises has been ported to Magritte 30 and Seaside 3.1. Magritte30 supports instance-based declarations while Magritte20 was only supporting class-based declarations. The exercises have been enhanced and are maintained by Stéphane Ducasse and Damien Cassou. 
 
-The exercises start simple and with detailled instructions on how to perform the given tasks. Exercises marked with a star are a bit trickier, you might want to solve them later on. Sometimes you will probably not exactly know what class to use, what method to call or what parameters to pass, use the power of Pharo (senders, implementers, references, ...) to browse the source-code of Magritte, you might even discover some other features that were not presented during this tutorial.
+The exercises start simple and with detailed instructions on how to perform the given tasks. Exercises marked with a star are a bit trickier, you might want to solve them later on. Sometimes you will probably not exactly know what class to use, what method to call or what parameters to pass, use the power of Pharo (senders, implementers, references, ...) to browse the source-code of Magritte, you might even discover some other features that were not presented during this tutorial.
 
 !!! Getting Started 
 
-Get an image and bring the Configuration Browser and install the stable version of MagritteContactManager.
+Get an image and bring the Catalog Browser and install the stable version of MagritteContactManager.
 
 In case you need to know where the code of the tutorial is saved. It is in the following repository:
 
@@ -25,7 +25,7 @@ If it is not, the seaside control panel from Tools menu of the world menu.
 
 !!! Juggle with Descriptions
 
-Have a look at the source-code of the classes ==CMPerson==, ==CMAddress==, and ==CMPhone==. In essence a person is described by different attributes such as it first name, name email, birthday... In addition it in relation with an address object and it has a list of phones. 
+Have a look at the source-code of the classes ==CMPerson==, ==CMAddress==, and ==CMPhone==. In essence a person is described by different attributes such as it first name, name email, birthday... In addition it is in relation with an address object and it has a list of phones. 
 
 Here are the class definitions. Note that the class names are a bit overkill with the Model prefix. In future versions, we may drop it. 
 
@@ -261,7 +261,7 @@ Let's see how one add a link to a page:
 MAPersonManager >> renderContentOn: html 
     html heading: 'Person Manager'.
     html anchor
-        callback: [ self add ]; with: [ html text: 'add'']
+        callback: [ self add ]; with: [ html text: 'add']
 ]]]
 
 !!! Exercise 8: Rendering the contacts
@@ -289,7 +289,7 @@ MAPersonManager >> renderContentOn: html
     html heading: 'Person Manager'. 
     html anchor
         callback: [ self add ];
-        with: [ html text: 'add'' ]. 
+        with: [ html text: 'add' ]. 
     html break.
     self persons
         do: [ :person | self renderLineForPerson: person on: html ] separatedBy: [ html break ]

--- a/Chapters/Magritte/MagritteTutorial.pillar
+++ b/Chapters/Magritte/MagritteTutorial.pillar
@@ -395,7 +395,7 @@ We initialize the report following the
 [[[language=smalltalk
 MAPersonManager >> initialize
     super initialize.
-    self report: (MAReport rows: self persons description: self persons first magritteDescription)
+    self report: (MAReport rows: self persons description: CMPerson new magritteDescription)
 ]]]
 
 Now we define the method ==children== to make sure that the report component is correctly returned. 
@@ -440,13 +440,13 @@ Right now almost all the information about a person is displayed within the repo
 MAPersonManager >> filteredDescriptionsFrom: aPerson
 
     ^ aPerson magritteDescription select: [ :each | 
-         #(firstName lastName email) includes: each accessor selector ] 
+         #(firstName lastName) includes: each accessor selector ] 
 ]]]
      
 [[[language=smalltalk
 MAPersonManager >> initialize
     super initialize.
-    self report: (MAReport rows: self persons description: (self  filteredDescriptionsFrom: self persons first))
+    self report: (MAReport rows: self persons description: (self  filteredDescriptionsFrom: CMPerson new))
 ]]]
 
 
@@ -511,9 +511,6 @@ MAPersonManager >> renderContentOn: html
 		separatedBy: [ html space ]. 
 	html render: self report
 ]]]
-
-SD: check because when pressing on editView I got a "requiresMultipartForm" is nil
-
 
 
 !! Giving access to end-users

--- a/Chapters/Magritte/MagritteTutorial.pillar
+++ b/Chapters/Magritte/MagritteTutorial.pillar
@@ -518,7 +518,7 @@ MAPersonManager >> renderContentOn: html
 As experience shows, customers are often not completely satisfied with the features the application developers are giving to them. They want more and they want to be able to customize everything by themselves. Thanks to the reflective nature of Magritte - all the descriptions within Magritte are described with Magritte descriptions itself - we can easily provide the necessary functionality to offer flexibility to end-users. 
 
 !!!Question 16
- Point your browser to http://localhost:8080/seaside/magritte/editor. You should get a browse navigating the different descriptions themselves. What you see is that a description is an object having multiple fields. 
+ Point your browser to http://localhost:8080/magritte/editor. You should get a browse navigating the different descriptions themselves. What you see is that a description is an object having multiple fields. 
 In addition since a description is also described using magritte we can get easily a editor to edit descriptions. 
 Browse the class ==MADescriptionEditor==: it is the one implementing the description example editor itself. 
 


### PR DESCRIPTION
Hi Stef,

I've reviewed the entire booklet and followed the exercises.

In this pull request I've included some little fixes I could commit directly.

By the other way, here are some other comments that didn't fit well in the pull request:

    1. I've found the root cause of the error when click on editView. It's necessary to remove:

componentClass: MAInternalEditorComponent

in the descriptionHomeAddress method.

    2. At least in my case, Magritte was not installed when I install Seaside3 (using the Catalog), so I had to install manually Magritte-Seaside after install Seaside.

    3. In section 2.4 (page 10), it is not clear how to get the web application running as expected in the figure 2-2. I think is missing the code to register the application. Something like:

    WAAdmin register: self asApplicationAt: 'address'

    4. I think some exercises are out of order. In particular, I think the Exercise 6 should go before all exercises in Chapter 4, because until the exercise 6 you still don't code a Seaside componente, however the Chapter 4 exercises refer to snapshots of the Seaside component.

 

